### PR TITLE
EKS IRSA/Pod Identity implementation simplification

### DIFF
--- a/internal/auth/eksIRSA.go
+++ b/internal/auth/eksIRSA.go
@@ -1,86 +1,54 @@
 package auth
 
 import (
-	"k8xauth/internal/logger"
-
 	"context"
 	"errors"
-	"fmt"
 	"os"
-	"time"
+	"strings"
 
-	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
-	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
-	"github.com/go-jose/go-jose/v4/jwt"
 	"golang.org/x/oauth2"
 )
 
-const (
-	SESSION = "IRSA_CREDS_SESSION"
-)
-
-func EksAWSIRSATokenSource(ctx context.Context) (oauth2.TokenSource, error) {
+// irsaTokenSource builds an oauth2.TokenSource from the web identity token file used by
+// EKS IRSA (IAM Roles for Service Accounts).
+func irsaTokenSource(_ context.Context) (oauth2.TokenSource, error) {
 	region := os.Getenv("AWS_REGION")
-	roleArn := os.Getenv("AWS_ROLE_ARN")
+	roleARN := os.Getenv("AWS_ROLE_ARN")
 	tokenFilePath := os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE")
 
-	if region == "" || roleArn == "" || tokenFilePath == "" {
+	if region == "" || roleARN == "" || tokenFilePath == "" {
 		return nil, errors.New("IRSA environment variables not set")
 	}
 
-	token, err := stscreds.IdentityTokenFile(tokenFilePath).GetIdentityToken()
-	if err != nil {
-		return nil, fmt.Errorf("retrieving IRSA identity token: %w", err)
-	}
-
-	t, err := jwt.ParseSigned(string(token), jwtSignatureAlgorithms) // parse without verification
-	if err != nil {
-		return nil, fmt.Errorf("parsing IRSA JWT: %w", err)
-	}
-
-	var claims map[string]any
-	if err := t.UnsafeClaimsWithoutVerification(&claims); err != nil {
-		return nil, fmt.Errorf("extracting JWT claims: %w", err)
-	}
-
-	exp, ok := claims["exp"]
-	if !ok {
-		return nil, errors.New("IRSA JWT missing exp claim")
-	}
-
-	// Create an OAuth2 token source using the assumed role's credentials
-	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{
-		AccessToken: string(token),
-		TokenType:   "Bearer",
-		Expiry:      time.Unix(int64(exp.(float64)), 0),
-	})
-
-	ts := oauth2.ReuseTokenSourceWithExpiry(nil, tokenSource, time.Duration(60*time.Second))
-
-	return ts, nil
+	return jwtFileTokenSource(tokenFilePath)
 }
 
 func eksIRSAAuth(ctx context.Context) (*clientAuth, error) {
-	awsTokenSource, err := EksAWSIRSATokenSource(ctx)
-	if awsTokenSource != nil && err == nil {
-		c := imds.New(imds.Options{})
-		i, err := c.GetInstanceIdentityDocument(ctx, nil)
-		if err != nil {
-			logger.Log.Debug("Couldn't fetch ProjectId from AWS/EKS metadata server")
-		}
-
-		identityToken, err := awsTokenSource.Token()
-		if err != nil {
-			logger.Log.Debug("Couldn't fetch identity token from AWS/EKS metadata server")
-		}
-
-		clientAuth := clientAuth{
-			platform:               "aws",
-			sessionIdentifier:      fmt.Sprintf("%s-%s", i.AccountID, i.InstanceID)[:32],
-			tokenSource:            &awsTokenSource,
-			identityTokenRetriever: identityTokenRetriever{token: []byte(identityToken.AccessToken)},
-		}
-		return &clientAuth, nil
+	awsTokenSource, err := irsaTokenSource(ctx)
+	if err != nil {
+		return nil, err
 	}
-	return nil, err
+
+	identityToken, err := awsTokenSource.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	// Derive session identifier from the role name (last "/"-delimited segment of the ARN).
+	roleARN := os.Getenv("AWS_ROLE_ARN")
+	sessionIdentifier := roleARN
+	if idx := strings.LastIndex(roleARN, "/"); idx >= 0 {
+		sessionIdentifier = roleARN[idx+1:]
+	}
+	if len(sessionIdentifier) > 32 {
+		sessionIdentifier = sessionIdentifier[:32]
+	}
+
+	ca := clientAuth{
+		platform:               "aws",
+		sessionIdentifier:      sessionIdentifier,
+		tokenSource:            &awsTokenSource,
+		identityTokenRetriever: identityTokenRetriever{token: []byte(identityToken.AccessToken)},
+	}
+	return &ca, nil
 }

--- a/internal/auth/eksPodIdentity.go
+++ b/internal/auth/eksPodIdentity.go
@@ -9,7 +9,6 @@ import (
 
 	"k8xauth/internal/logger"
 
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/go-jose/go-jose/v4/jwt"
 	"golang.org/x/oauth2"
@@ -27,24 +26,11 @@ func eksPodIdentityAuth(ctx context.Context) (*clientAuth, error) {
 
 	logger.Log.Debug("Detected EKS Pod Identity credentials endpoint", "uri", credentialsURI)
 
-	// Load default config which will use Pod Identity credentials
-	cfg, err := config.LoadDefaultConfig(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load AWS config for Pod Identity: %w", err)
+	// Derive session identifier from the Kubernetes pod name.
+	sessionIdentifier := os.Getenv("HOSTNAME")
+	if sessionIdentifier == "" {
+		sessionIdentifier = "podidentity"
 	}
-
-	// Verify we can retrieve credentials
-	creds, err := cfg.Credentials.Retrieve(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve Pod Identity credentials: %w", err)
-	}
-
-	logger.Log.Debug("Successfully retrieved Pod Identity credentials", "accessKeyId", creds.AccessKeyID[:8]+"...")
-
-	// Derive session identifier from the access key ID to avoid
-	// extra network calls (STS GetCallerIdentity, IMDS) that may
-	// time out or fail in restricted pod environments.
-	sessionIdentifier := fmt.Sprintf("podidentity-%s", creds.AccessKeyID)
 	if len(sessionIdentifier) > 32 {
 		sessionIdentifier = sessionIdentifier[:32]
 	}
@@ -60,7 +46,7 @@ func eksPodIdentityAuth(ctx context.Context) (*clientAuth, error) {
 	// It contains a JWT signed by the cluster's OIDC issuer (audience: pods.eks.amazonaws.com)
 	// and can be used directly as an OIDC bearer token for generic-oidc consumers.
 	if tokenFilePath := os.Getenv("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE"); tokenFilePath != "" {
-		ts, err := podIdentityTokenSource(tokenFilePath)
+		ts, err := jwtFileTokenSource(tokenFilePath)
 		if err != nil {
 			logger.Log.Debug("Failed to build OIDC token source from Pod Identity authorization token file", "error", err.Error())
 		} else {
@@ -78,28 +64,27 @@ func eksPodIdentityAuth(ctx context.Context) (*clientAuth, error) {
 	return ca, nil
 }
 
-// podIdentityTokenSource reads the Kubernetes SA token injected by the Pod Identity webhook
-// and wraps it in an oauth2.TokenSource. The token is a JWT whose expiry is extracted from
-// the 'exp' claim and used to schedule refresh.
-func podIdentityTokenSource(tokenFilePath string) (oauth2.TokenSource, error) {
+// jwtFileTokenSource reads a JWT from tokenFilePath, extracts its expiry from the 'exp' claim,
+// and wraps it in an oauth2.TokenSource that refreshes 60 s before expiry.
+func jwtFileTokenSource(tokenFilePath string) (oauth2.TokenSource, error) {
 	token, err := stscreds.IdentityTokenFile(tokenFilePath).GetIdentityToken()
 	if err != nil {
-		return nil, fmt.Errorf("failed to read authorization token file: %w", err)
+		return nil, fmt.Errorf("failed to read token file: %w", err)
 	}
 
 	t, err := jwt.ParseSigned(string(token), jwtSignatureAlgorithms) // parse without signature verification
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse authorization token JWT: %w", err)
+		return nil, fmt.Errorf("failed to parse token JWT: %w", err)
 	}
 
 	var claims map[string]any
 	if err := t.UnsafeClaimsWithoutVerification(&claims); err != nil {
-		return nil, fmt.Errorf("failed to extract claims from authorization token: %w", err)
+		return nil, fmt.Errorf("failed to extract claims from token: %w", err)
 	}
 
 	exp, ok := claims["exp"]
 	if !ok {
-		return nil, errors.New("authorization token JWT has no exp claim")
+		return nil, errors.New("token JWT has no exp claim")
 	}
 
 	staticTS := oauth2.StaticTokenSource(&oauth2.Token{


### PR DESCRIPTION
This pull request refactors and simplifies the authentication logic for AWS EKS IRSA and Pod Identity in the `internal/auth` package. The main improvements are the consolidation of token source logic, removal of unnecessary AWS SDK dependencies, and simplification of session identifier derivation. These changes improve maintainability and reduce external dependencies.

**Refactoring and simplification of token source logic:**

* Consolidated the logic for reading and parsing JWT tokens from files into a single function, `jwtFileTokenSource`, which is now used by both IRSA and Pod Identity authentication flows. This reduces code duplication and standardizes error handling. [[1]](diffhunk://#diff-3ca60f1c1db0564ea2dfad45dd30a5551e67a53dd2b83f737e5fe3fd7e37f213L4-R53) [[2]](diffhunk://#diff-ca679fa0629dbe36471fe4ab3d74385cd549e4882090294b4121895607e751a2L63-R49) [[3]](diffhunk://#diff-ca679fa0629dbe36471fe4ab3d74385cd549e4882090294b4121895607e751a2L81-R87)

* Simplified the `eksIRSAAuth` function by removing unnecessary AWS SDK and STS credential retrieval, instead directly using the web identity token file for authentication.

**Dependency and error handling improvements:**

* Removed unused AWS SDK imports from `eksIRSA.go`, reducing the binary size and surface area for potential issues. [[1]](diffhunk://#diff-3ca60f1c1db0564ea2dfad45dd30a5551e67a53dd2b83f737e5fe3fd7e37f213L4-R53) [[2]](diffhunk://#diff-ca679fa0629dbe36471fe4ab3d74385cd549e4882090294b4121895607e751a2L12)

* Standardized and clarified error messages in the JWT token parsing and claim extraction process, making debugging easier.

**Session identifier derivation changes:**

* Changed the session identifier in `eksPodIdentityAuth` to derive from the pod's hostname (environment variable `HOSTNAME`) instead of making network calls for AWS credentials, which improves reliability in restricted environments.

* Updated the session identifier logic in `eksIRSAAuth` to use the last segment of the `AWS_ROLE_ARN`, truncated to 32 characters, for consistency and uniqueness.