### PR TITLE
Add toolchain to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module k8xauth
 
 go 1.26.1
 
+toolchain go1.26.2
+
 require (
 	cloud.google.com/go/compute/metadata v0.9.0
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0


### PR DESCRIPTION
This pull request makes a minor update to the Go toolchain version in the `go.mod` file for the `k8xauth` module, specifying the use of Go 1.26.2 instead of the previous default.

- Updated the `go.mod` file to specify `toolchain go1.26.2`, ensuring builds use the latest Go 1.26.2 toolchain.